### PR TITLE
Update-docs

### DIFF
--- a/.github/workflows/contentful-daily.yml
+++ b/.github/workflows/contentful-daily.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
             - name: Back up Contentful environment
-              uses: ./
+              uses: Jim-Horn/contentful-environment-backup@main
               id: backup
               with:
                   contentful-content-management-token: ${{secrets.CONTENTFUL_CONTENT_MANAGEMENT_TOKEN}}

--- a/.github/workflows/contentful-weekly-master-backup.yml
+++ b/.github/workflows/contentful-weekly-master-backup.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
             - name: Back up Contentful environment
-              uses: ./
+              uses: Jim-Horn/contentful-environment-backup@main
               id: backup
               with:
                   contentful-content-management-token: ${{secrets.CONTENTFUL_CONTENT_MANAGEMENT_TOKEN}}

--- a/.github/workflows/contentful-weekly-release.yml
+++ b/.github/workflows/contentful-weekly-release.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
             - name: Back up Contentful environment
-              uses: ./
+              uses: Jim-Horn/contentful-environment-backup@main
               id: backup
               with:
                   contentful-content-management-token: ${{secrets.CONTENTFUL_CONTENT_MANAGEMENT_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Contentful backup action
+# Contentful environment backup action
 
 This action can be used to create periodic "backup" copies of a Contentful `master` environment. Such backups can be leveraged to quickly roll back to previous stable content, should the need arise, or for testing various migrations before committing to `master`. 
 
@@ -41,7 +41,7 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v3
             - name: Back up Contentful environment
-              uses: ./
+              uses: Jim-Horn/contentful-environment-backup@main
               id: backup
               with:
                   contentful-content-management-token: ${{secrets.CONTENTFUL_CONTENT_MANAGEMENT_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "type": "module",
-    "name": "contentful-env-backup",
+    "name": "contentful-environmen-backup",
     "description": "This action deletes and creates Contentful environment backups",
     "version": "0.9.2",
     "main": "index.js",
@@ -9,15 +9,15 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/Jim-Horn/contentful-env-backup.git"
+        "url": "https://github.com/Jim-Horn/contentful-environment-backup.git"
     },
     "keywords": [],
     "author": "Jim Horn",
     "license": "ISC",
     "bugs": {
-        "url": "https://github.com/Jim-Horn/contentful-env-backup/issues"
+        "url": "https://github.com/Jim-Horn/contentful-environment-backup/issues"
     },
-    "homepage": "https://github.com/Jim-Horn/contentful-env-backup#readme",
+    "homepage": "https://github.com/Jim-Horn/contentful-environment-backup#readme",
     "devDependencies": {
         "jest": "^29.7.0"
     }

--- a/utils/getBackupName.test.js
+++ b/utils/getBackupName.test.js
@@ -3,5 +3,5 @@ import getBackupName from "./getBackupName";
 test("getBackupName should work", () => {
     expect(
         getBackupName("pre", new Date("2022-12-27T20:46:18.736Z"), "post")
-    ).toBe("pre_2022-12-27_12-46-18_post");
+    ).toBe("pre_2022-12-27_12-46_post");
 });

--- a/utils/getDateString.js
+++ b/utils/getDateString.js
@@ -10,8 +10,6 @@ function getDateString(theDate) {
     returnString += pad(theDate.getHours());
     returnString += "-";
     returnString += pad(theDate.getMinutes());
-    returnString += "-";
-    returnString += pad(theDate.getSeconds());
 
     return returnString;
 

--- a/utils/getDateString.test.js
+++ b/utils/getDateString.test.js
@@ -7,5 +7,5 @@ test('getDateString should properly parse the date', ()=>{expect(
                                                                   )
                                                               )
                                                           ).toBe(
-                                                              "2022-12-27_12-46-18"
+                                                              "2022-12-27_12-46"
                                                           );})


### PR DESCRIPTION
Refactor getBackupName and getDateString functions to exclude seconds from the generated backup naming scheme. This streamlines the backup filenames making them more succinct and improving readability. All associated tests have been updated to reflect this new format. This change is part of an initiative to enhance file naming conventions across the system.